### PR TITLE
Integrate OpenCog with Archon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,12 @@ PRIMARY_MODEL=
 # Example for Ollama: nomic-embed-text
 # Example for OpenAI: text-embedding-3-small
 EMBEDDING_MODEL=
+
+# Path to the OpenCog cogutil component
+OPENGOG_COGUTIL_PATH=
+
+# Path to the OpenCog atomspace component
+OPENGOG_ATOMSPACE_PATH=
+
+# Path to the OpenCog cogserver component
+OPENGOG_COGSERVER_PATH=

--- a/archon/advisor_agent.py
+++ b/archon/advisor_agent.py
@@ -22,6 +22,12 @@ from utils.utils import get_env_var
 from archon.agent_prompts import advisor_prompt
 from archon.agent_tools import get_file_content_tool
 
+# Import OpenCog dependencies
+import opencog
+import opencog.atomspace
+import opencog.cogserver
+import opencog.utilities
+
 load_dotenv()
 
 provider = get_env_var('LLM_PROVIDER') or 'OpenAI'
@@ -36,6 +42,9 @@ logfire.configure(send_to_logfire='if-token-present')
 @dataclass
 class AdvisorDeps:
     file_list: List[str]
+    atomspace: Any
+    cogserver: Any
+    utilities: Any
 
 advisor_agent = Agent(
     model,
@@ -57,11 +66,12 @@ def add_file_list(ctx: RunContext[str]) -> str:
     """
 
 @advisor_agent.tool_plain
-def get_file_content(file_path: str) -> str:
+def get_file_content(ctx: RunContext[AdvisorDeps], file_path: str) -> str:
     """
     Retrieves the content of a specific file. Use this to get the contents of an example, tool, config for an MCP server
     
     Args:
+        ctx: The context including OpenCog components
         file_path: The path to the file
         
     Returns:

--- a/graph_service.py
+++ b/graph_service.py
@@ -4,7 +4,13 @@ from typing import Optional, Dict, Any
 from archon.archon_graph import agentic_flow
 from langgraph.types import Command
 from utils.utils import write_to_log
-    
+
+# Import OpenCog dependencies
+import opencog
+import opencog.atomspace
+import opencog.cogserver
+import opencog.utilities
+
 app = FastAPI()
 
 class InvokeRequest(BaseModel):
@@ -39,11 +45,16 @@ async def invoke_agent(request: InvokeRequest):
             }
         }
 
+        # Initialize OpenCog components
+        atomspace = opencog.atomspace.AtomSpace()
+        cogserver = opencog.cogserver.CogServer(atomspace)
+        utilities = opencog.utilities.Utilities(atomspace)
+
         response = ""
         if request.is_first_message:
             write_to_log(f"Processing first message for thread {request.thread_id}")
             async for msg in agentic_flow.astream(
-                {"latest_user_message": request.message}, 
+                {"latest_user_message": request.message, "atomspace": atomspace, "cogserver": cogserver, "utilities": utilities}, 
                 config,
                 stream_mode="custom"
             ):


### PR DESCRIPTION
Integrate OpenCog components into the Archon project.

* **Environment Variables**:
  - Add `OPENGOG_COGUTIL_PATH`, `OPENGOG_ATOMSPACE_PATH`, and `OPENGOG_COGSERVER_PATH` environment variables to `.env.example`.

* **Archon Graph**:
  - Import OpenCog modules in `archon/archon_graph.py`.
  - Initialize OpenCog components in the `define_scope_with_reasoner` function.
  - Update `AgentState` class to include OpenCog components.
  - Return OpenCog components from `define_scope_with_reasoner`.

* **Advisor Agent**:
  - Import OpenCog modules in `archon/advisor_agent.py`.
  - Update `AdvisorDeps` class to include OpenCog components.
  - Modify `get_file_content` function to accept OpenCog components.

* **Graph Service**:
  - Import OpenCog modules in `graph_service.py`.
  - Initialize OpenCog components in the `invoke_agent` function.
  - Pass OpenCog components as dependencies to the `agentic_flow` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EchoCog/Archon/pull/1?shareId=7383499a-8d15-498c-81c9-ba9ca644cd2b).